### PR TITLE
feat: add static block to explicitly register MySQL JDBC driver

### DIFF
--- a/flowchain/src/main/java/com/flowchain/db/DBConnection.java
+++ b/flowchain/src/main/java/com/flowchain/db/DBConnection.java
@@ -19,6 +19,15 @@ public final class DBConnection {
     private static final String PROPERTIES_FILE = "db.properties";
     private static final Properties PROPS = loadProperties();
 
+    static {
+        try {
+            Class.forName("com.mysql.cj.jdbc.Driver");
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException(
+                "MySQL JDBC driver not found. Ensure mysql-connector-j is in WEB-INF/lib/.", e);
+        }
+    }
+
     private DBConnection() {
         // utility class
     }


### PR DESCRIPTION
## Summary                                                                                                  
                                                                                                              
  Fixes `java.sql.SQLException: No suitable driver found for jdbc:mysql://...` that occurred on every database
   operation (register, login) when running under Tomcat 9.                                                   
                                                                                
  ## The problem was...                                                                                       
   
  JDBC 4.0+ drivers are supposed to auto-register via the `META-INF/services/java.sql.Driver` SPI mechanism — 
  the MySQL Connector/J JAR includes this file, so in a standalone Java application,
  `DriverManager.getConnection()` finds the driver without any explicit loading.

## The fix
Added a `static { Class.forName("com.mysql.cj.jdbc.Driver"); }` block in `DBConnection.java`. This runs once
   when the class is first loaded, explicitly registering the MySQL driver with `DriverManager` from within
  the webapp's classloader context — making it visible to subsequent `getConnection()` calls.
     
## Test plan
  - [x] `POST /register` — successfully creates org + user + location + orgmember + auditlog    
  
<img width="1470" height="956" alt="Screenshot 2026-04-14 at 8 59 01 AM" src="https://github.com/user-attachments/assets/3a2d1819-6846-4c97-ad18-53592e80ba21" />
              
  - [x] `POST /login` — successfully authenticates and redirects by role        
  - [x] `POST /logout` — invalidates session and redirects to home
  - [x] Verified new rows in MySQL Workbench (bcrypt hash in `users.password`, `PENDING` status, `OWNER`
  member role, `REGISTER` audit log)
### User Table
<img width="604" height="115" alt="Screenshot 2026-04-14 at 9 08 11 AM" src="https://github.com/user-attachments/assets/58e607a1-6ba6-4e1c-b5dd-07160dccaf3d" />

### Audit Log Table
<img width="403" height="81" alt="Screenshot 2026-04-14 at 9 08 25 AM" src="https://github.com/user-attachments/assets/0a23e4ce-19d6-4dc9-ae0a-2c89c2d24604" />


