### PR TITLE
feat: add password change and account deletion

### DIFF
--- a/flowchain/src/main/java/com/flowchain/filter/AuthFilter.java
+++ b/flowchain/src/main/java/com/flowchain/filter/AuthFilter.java
@@ -16,11 +16,12 @@ import javax.servlet.http.HttpSession;
  *   /donor/*     → DONOR
  *   /recipient/* → RECIPIENT
  *   /admin/*     → ADMIN
+ *   /account/*   → any authenticated user (no role check)
  *
  * Unauthenticated requests are redirected to /login?next=<original>.
  * Authenticated requests with the wrong role get 403.
  */
-@WebFilter(urlPatterns = {"/donor/*", "/recipient/*", "/admin/*"})
+@WebFilter(urlPatterns = {"/donor/*", "/recipient/*", "/admin/*", "/account", "/account/*"})
 public class AuthFilter implements Filter {
 
     @Override

--- a/flowchain/src/main/java/com/flowchain/servlet/AccountDeleteServlet.java
+++ b/flowchain/src/main/java/com/flowchain/servlet/AccountDeleteServlet.java
@@ -1,0 +1,110 @@
+package com.flowchain.servlet;
+
+import com.flowchain.db.DBConnection;
+import com.flowchain.util.CsrfUtil;
+import com.flowchain.util.PasswordUtil;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+/**
+ * POST /account/delete
+ *
+ * Deletes the currently logged-in user's account after verifying their
+ * password.  DELETE FROM users cascades to orgmembers and auditlogs, so
+ * all of this user's historical audit trail is wiped along with the user
+ * row.  No ACCOUNT_DELETE audit log is written because the FK cascade
+ * would immediately erase it too — recording the deletion in a way that
+ * survives would require a schema change (e.g. SET NULL on the FK, or a
+ * separate deletion-events table).
+ *
+ * The organization the user belonged to is intentionally NOT deleted,
+ * even if this user was its only member.  Orphaned orgs can be cleaned
+ * up by an admin later.
+ *
+ * On success: session invalidated, redirect to "/".
+ */
+@WebServlet("/account/delete")
+public class AccountDeleteServlet extends HttpServlet {
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse res)
+            throws ServletException, IOException {
+
+        if (!CsrfUtil.isValid(req)) {
+            res.sendError(HttpServletResponse.SC_FORBIDDEN, "Invalid CSRF token");
+            return;
+        }
+
+        HttpSession session = req.getSession(false);
+        if (session == null || session.getAttribute("userId") == null) {
+            res.sendRedirect(req.getContextPath() + "/login");
+            return;
+        }
+
+        int userId = (Integer) session.getAttribute("userId");
+        String confirmPassword = req.getParameter("confirmPassword");
+
+        if (confirmPassword == null || confirmPassword.isEmpty()) {
+            renderError(req, res, "Please enter your password to confirm deletion.");
+            return;
+        }
+
+        try {
+            String storedHash = findPasswordHash(userId);
+            if (storedHash == null || !PasswordUtil.verify(confirmPassword, storedHash)) {
+                renderError(req, res, "Password is incorrect. Account not deleted.");
+                return;
+            }
+
+            deleteUser(userId);
+            session.invalidate();
+            res.sendRedirect(req.getContextPath() + "/?deleted=1");
+
+        } catch (SQLException e) {
+            getServletContext().log("Account deletion failed for user " + userId, e);
+            renderError(req, res, "Could not delete account. Please try again.");
+        }
+    }
+
+    /* ------------------------------------------------------------ */
+
+    private static String findPasswordHash(int userId) throws SQLException {
+        String sql = "SELECT password FROM users WHERE user_id = ?";
+        try (Connection conn = DBConnection.get();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, userId);
+            try (ResultSet rs = ps.executeQuery()) {
+                return rs.next() ? rs.getString("password") : null;
+            }
+        }
+    }
+
+    private static void deleteUser(int userId) throws SQLException {
+        String sql = "DELETE FROM users WHERE user_id = ?";
+        try (Connection conn = DBConnection.get();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, userId);
+            ps.executeUpdate();
+        }
+    }
+
+    /* ------------------------------------------------------------ */
+
+    private void renderError(HttpServletRequest req, HttpServletResponse res, String message)
+            throws ServletException, IOException {
+        req.setAttribute("deleteError", message);
+        req.setAttribute("csrfToken", CsrfUtil.getOrCreate(req));
+        res.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        req.getRequestDispatcher("/WEB-INF/views/account.jsp").forward(req, res);
+    }
+}

--- a/flowchain/src/main/java/com/flowchain/servlet/AccountServlet.java
+++ b/flowchain/src/main/java/com/flowchain/servlet/AccountServlet.java
@@ -1,0 +1,27 @@
+package com.flowchain.servlet;
+
+import com.flowchain.util.CsrfUtil;
+
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * GET /account → render the account settings page (password change + account deletion)
+ *
+ * AuthFilter has already verified the user is logged in; any authenticated user
+ * (DONOR / RECIPIENT / ADMIN) can manage their own account here.
+ */
+@WebServlet("/account")
+public class AccountServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse res)
+            throws ServletException, IOException {
+        req.setAttribute("csrfToken", CsrfUtil.getOrCreate(req));
+        req.getRequestDispatcher("/WEB-INF/views/account.jsp").forward(req, res);
+    }
+}

--- a/flowchain/src/main/java/com/flowchain/servlet/PasswordChangeServlet.java
+++ b/flowchain/src/main/java/com/flowchain/servlet/PasswordChangeServlet.java
@@ -1,0 +1,157 @@
+package com.flowchain.servlet;
+
+import com.flowchain.db.DBConnection;
+import com.flowchain.util.CsrfUtil;
+import com.flowchain.util.PasswordUtil;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+/**
+ * POST /account/password
+ *
+ * Validates the current password, checks the new password meets our length
+ * requirement and matches its confirmation, then UPDATEs users.password and
+ * writes a PASSWORD_CHANGE audit log entry.
+ *
+ * Session stays active — user is not forced to log back in.
+ */
+@WebServlet("/account/password")
+public class PasswordChangeServlet extends HttpServlet {
+
+    private static final int MIN_PASSWORD_LEN = 8;
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse res)
+            throws ServletException, IOException {
+
+        if (!CsrfUtil.isValid(req)) {
+            res.sendError(HttpServletResponse.SC_FORBIDDEN, "Invalid CSRF token");
+            return;
+        }
+
+        HttpSession session = req.getSession(false);
+        if (session == null || session.getAttribute("userId") == null) {
+            res.sendRedirect(req.getContextPath() + "/login");
+            return;
+        }
+
+        int userId = (Integer) session.getAttribute("userId");
+
+        String currentPassword     = req.getParameter("currentPassword");
+        String newPassword         = req.getParameter("newPassword");
+        String confirmNewPassword  = req.getParameter("confirmNewPassword");
+
+        // Validate input
+        if (isBlank(currentPassword) || isBlank(newPassword) || isBlank(confirmNewPassword)) {
+            renderError(req, res, "All password fields are required.");
+            return;
+        }
+        if (newPassword.length() < MIN_PASSWORD_LEN) {
+            renderError(req, res,
+                "New password must be at least " + MIN_PASSWORD_LEN + " characters.");
+            return;
+        }
+        if (!newPassword.equals(confirmNewPassword)) {
+            renderError(req, res, "New passwords do not match.");
+            return;
+        }
+        if (newPassword.equals(currentPassword)) {
+            renderError(req, res, "New password must be different from the current password.");
+            return;
+        }
+
+        try {
+            String storedHash = findPasswordHash(userId);
+            if (storedHash == null || !PasswordUtil.verify(currentPassword, storedHash)) {
+                renderError(req, res, "Current password is incorrect.");
+                return;
+            }
+
+            String newHash = PasswordUtil.hash(newPassword);
+            updatePasswordAndAudit(userId, newHash);
+
+            // Stay on the account page with a success message
+            req.setAttribute("successMessage", "Password updated successfully.");
+            req.setAttribute("csrfToken", CsrfUtil.getOrCreate(req));
+            req.getRequestDispatcher("/WEB-INF/views/account.jsp").forward(req, res);
+
+        } catch (SQLException e) {
+            getServletContext().log("Password change failed for user " + userId, e);
+            renderError(req, res, "Could not update password. Please try again.");
+        }
+    }
+
+    /* ------------------------------------------------------------ */
+
+    private static String findPasswordHash(int userId) throws SQLException {
+        String sql = "SELECT password FROM users WHERE user_id = ?";
+        try (Connection conn = DBConnection.get();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, userId);
+            try (ResultSet rs = ps.executeQuery()) {
+                return rs.next() ? rs.getString("password") : null;
+            }
+        }
+    }
+
+    private static void updatePasswordAndAudit(int userId, String newHash) throws SQLException {
+        try (Connection conn = DBConnection.get()) {
+            conn.setAutoCommit(false);
+            try {
+                try (PreparedStatement ps = conn.prepareStatement(
+                        "UPDATE users SET password = ? WHERE user_id = ?")) {
+                    ps.setString(1, newHash);
+                    ps.setInt(2, userId);
+                    ps.executeUpdate();
+                }
+
+                int logId;
+                try (PreparedStatement ps = conn.prepareStatement(
+                        "SELECT COALESCE(MAX(log_id), 0) + 1 FROM auditlogs");
+                     ResultSet rs = ps.executeQuery()) {
+                    rs.next();
+                    logId = rs.getInt(1);
+                }
+
+                try (PreparedStatement ps = conn.prepareStatement(
+                        "INSERT INTO auditlogs (log_id, user_id, action_type, entity_type, "
+                      + "entity_id, action_time) VALUES (?, ?, 'PASSWORD_CHANGE', 'USER', ?, ?)")) {
+                    ps.setInt      (1, logId);
+                    ps.setInt      (2, userId);
+                    ps.setInt      (3, userId);
+                    ps.setTimestamp(4, Timestamp.valueOf(LocalDateTime.now()));
+                    ps.executeUpdate();
+                }
+
+                conn.commit();
+            } catch (SQLException e) {
+                conn.rollback();
+                throw e;
+            }
+        }
+    }
+
+    /* ------------------------------------------------------------ */
+
+    private void renderError(HttpServletRequest req, HttpServletResponse res, String message)
+            throws ServletException, IOException {
+        req.setAttribute("passwordError", message);
+        req.setAttribute("csrfToken", CsrfUtil.getOrCreate(req));
+        res.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        req.getRequestDispatcher("/WEB-INF/views/account.jsp").forward(req, res);
+    }
+
+    private static boolean isBlank(String s) { return s == null || s.isEmpty(); }
+}

--- a/flowchain/src/main/webapp/WEB-INF/views/account.jsp
+++ b/flowchain/src/main/webapp/WEB-INF/views/account.jsp
@@ -1,0 +1,112 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<c:set var="pageTitle" value="Account Settings" />
+<%@ include file="header.jspf" %>
+
+<main class="dashboard-page">
+  <div class="container">
+
+    <%-- Back to dashboard --%>
+    <c:choose>
+      <c:when test="${sessionScope.role == 'RECIPIENT'}">
+        <c:set var="dashUrl" value="${pageContext.request.contextPath}/recipient/dashboard" />
+      </c:when>
+      <c:when test="${sessionScope.role == 'ADMIN'}">
+        <c:set var="dashUrl" value="${pageContext.request.contextPath}/admin/dashboard" />
+      </c:when>
+      <c:otherwise>
+        <c:set var="dashUrl" value="${pageContext.request.contextPath}/donor/dashboard" />
+      </c:otherwise>
+    </c:choose>
+    <a href="${dashUrl}" class="btn btn-outline btn-sm detail-back-btn">Back to Dashboard</a>
+
+    <h1 class="dashboard-title">Account Settings</h1>
+    <p class="dashboard-sub">
+      Manage your password or permanently delete your account.
+    </p>
+
+    <%-- Success banner (after password change) --%>
+    <c:if test="${not empty successMessage}">
+      <div class="form-success-banner">
+        <c:out value="${successMessage}" />
+      </div>
+    </c:if>
+
+    <%-- ====================================================== --%>
+    <%-- Change Password                                         --%>
+    <%-- ====================================================== --%>
+    <div class="auth-card auth-card-wide account-section">
+      <h2 class="auth-title">Change Password</h2>
+      <p class="auth-sub">
+        You'll need your current password to set a new one. Minimum 8 characters.
+      </p>
+
+      <c:if test="${not empty passwordError}">
+        <div class="form-error-banner">
+          <c:out value="${passwordError}" />
+        </div>
+      </c:if>
+
+      <form action="${pageContext.request.contextPath}/account/password"
+            method="post" class="auth-form" novalidate>
+        <input type="hidden" name="csrfToken" value="<c:out value='${csrfToken}' />">
+
+        <div class="form-row">
+          <label for="currentPassword">Current password</label>
+          <input type="password" id="currentPassword" name="currentPassword"
+                 maxlength="100" required autocomplete="current-password">
+        </div>
+
+        <div class="form-grid-2">
+          <div class="form-row">
+            <label for="newPassword">New password</label>
+            <input type="password" id="newPassword" name="newPassword"
+                   minlength="8" maxlength="100" required autocomplete="new-password">
+          </div>
+          <div class="form-row">
+            <label for="confirmNewPassword">Confirm new password</label>
+            <input type="password" id="confirmNewPassword" name="confirmNewPassword"
+                   minlength="8" maxlength="100" required autocomplete="new-password">
+          </div>
+        </div>
+
+        <button type="submit" class="btn btn-primary auth-submit">Update Password</button>
+      </form>
+    </div>
+
+    <%-- ====================================================== --%>
+    <%-- Danger Zone — Delete Account                            --%>
+    <%-- ====================================================== --%>
+    <div class="auth-card auth-card-wide account-danger-zone">
+      <h2 class="auth-title danger-title">Delete Account</h2>
+      <p class="auth-sub">
+        This will permanently delete your account and remove you from your
+        organization. This action <strong>cannot be undone</strong>.
+        Your organization itself will not be deleted.
+      </p>
+
+      <c:if test="${not empty deleteError}">
+        <div class="form-error-banner">
+          <c:out value="${deleteError}" />
+        </div>
+      </c:if>
+
+      <form action="${pageContext.request.contextPath}/account/delete"
+            method="post" class="auth-form" novalidate
+            onsubmit="return confirm('Are you sure you want to permanently delete your account? This cannot be undone.');">
+        <input type="hidden" name="csrfToken" value="<c:out value='${csrfToken}' />">
+
+        <div class="form-row">
+          <label for="confirmPassword">Enter your password to confirm</label>
+          <input type="password" id="confirmPassword" name="confirmPassword"
+                 maxlength="100" required autocomplete="current-password">
+        </div>
+
+        <button type="submit" class="btn btn-danger auth-submit">Delete My Account</button>
+      </form>
+    </div>
+
+  </div>
+</main>
+
+<%@ include file="footer.jspf" %>

--- a/flowchain/src/main/webapp/WEB-INF/views/admin-dashboard.jsp
+++ b/flowchain/src/main/webapp/WEB-INF/views/admin-dashboard.jsp
@@ -15,6 +15,8 @@
     <div class="dashboard-actions">
       <a href="${pageContext.request.contextPath}/admin/org"
          class="btn btn-outline">Manage My Organization</a>
+      <a href="${pageContext.request.contextPath}/account"
+         class="btn btn-outline">Account Settings</a>
     </div>
 
     <div class="dashboard-placeholder">

--- a/flowchain/src/main/webapp/WEB-INF/views/donor-dashboard.jsp
+++ b/flowchain/src/main/webapp/WEB-INF/views/donor-dashboard.jsp
@@ -15,6 +15,8 @@
     <div class="dashboard-actions">
       <a href="${pageContext.request.contextPath}/donor/profile"
          class="btn btn-outline">Manage Organization</a>
+      <a href="${pageContext.request.contextPath}/account"
+         class="btn btn-outline">Account Settings</a>
     </div>
 
     <div class="dashboard-placeholder">

--- a/flowchain/src/main/webapp/WEB-INF/views/recipient-dashboard.jsp
+++ b/flowchain/src/main/webapp/WEB-INF/views/recipient-dashboard.jsp
@@ -24,6 +24,10 @@
          class="btn btn-outline">
         Manage Organization
       </a>
+      <a href="${pageContext.request.contextPath}/account"
+         class="btn btn-outline">
+        Account Settings
+      </a>
     </div>
 
     <!-- Info Section -->

--- a/flowchain/src/main/webapp/css/style.css
+++ b/flowchain/src/main/webapp/css/style.css
@@ -854,6 +854,33 @@ img {
   }
 }
 
+/* === ACCOUNT SETTINGS === */
+
+.account-section {
+  margin: 0 auto 28px;
+}
+
+.account-danger-zone {
+  margin: 0 auto 48px;
+  border: 1px solid rgba(239, 83, 80, 0.35);
+  background: rgba(239, 83, 80, 0.04);
+}
+
+.danger-title {
+  color: #ef9a9a;
+}
+
+.btn-danger {
+  background: #c62828;
+  color: var(--white);
+  border: 2px solid #c62828;
+}
+
+.btn-danger:hover {
+  background: #b71c1c;
+  border-color: #b71c1c;
+}
+
 /* === ORG PROFILE === */
 
 .form-success-banner {


### PR DESCRIPTION
Implements Issue #4 scope for this PR — self-service password change and account deletion for any authenticated user.  Admin password reset UI is deferred to a separate PR.

Endpoints:
- GET  /account           → AccountServlet (render settings page)
- POST /account/password  → PasswordChangeServlet
- POST /account/delete    → AccountDeleteServlet

Password change:
- Requires current password (bcrypt-verified)
- New password min 8 chars, must match confirmation
- Rejects unchanged password
- UPDATEs users.password + writes PASSWORD_CHANGE audit log
- Session stays active (no re-login required)

Account deletion:
- Requires password re-entry (bcrypt-verified) and a JS confirm()
- DELETE FROM users cascades to orgmembers and auditlogs
- The user's organization is intentionally NOT deleted
- No ACCOUNT_DELETE audit log is written — the FK cascade on auditlogs.user_id would immediately erase it anyway
- Session invalidated, redirect to /?deleted=1

AuthFilter now also guards /account and /account/* — any authenticated user (DONOR / RECIPIENT / ADMIN) can manage their own account.
