### PR TITLE
style: center-align navigation action buttons vertically

### DIFF
--- a/flowchain/src/main/webapp/css/style.css
+++ b/flowchain/src/main/webapp/css/style.css
@@ -188,6 +188,7 @@ img {
 
 .nav-actions {
   display: flex;
+  align-items: center;
   gap: 12px;
 }
 


### PR DESCRIPTION
Before:
<img width="1470" height="106" alt="Screenshot_2026-04-28_at_5 50 36_PM" src="https://github.com/user-attachments/assets/9882ab94-ffa5-4f8e-9e30-f3b31aa5fa34" />
After:
<img width="1470" height="107" alt="Screenshot 2026-05-06 at 9 21 53 PM" src="https://github.com/user-attachments/assets/21a183be-7580-4ddb-911d-9905e5297924" />

Different name for each page, but it doesn't matter for this change.
