### PR TITLE
feat: implement admin claim approval and rejection functionality

### DIFF
--- a/flowchain/src/main/java/com/flowchain/servlet/AdminClaimActionServlet.java
+++ b/flowchain/src/main/java/com/flowchain/servlet/AdminClaimActionServlet.java
@@ -1,0 +1,178 @@
+package com.flowchain.servlet;
+
+import com.flowchain.db.DBConnection;
+import com.flowchain.util.CsrfUtil;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+@WebServlet("/admin/claim/action")
+public class AdminClaimActionServlet extends HttpServlet {
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse res)
+            throws ServletException, IOException {
+
+        if (!CsrfUtil.isValid(req)) {
+            res.sendError(HttpServletResponse.SC_FORBIDDEN, "Invalid CSRF token");
+            return;
+        }
+
+        HttpSession session = req.getSession(false);
+        String role = getSessionRole(session);
+        Integer userId = getSessionUserId(session);
+
+        if (!"ADMIN".equals(role) || userId == null) {
+            res.sendError(HttpServletResponse.SC_FORBIDDEN);
+            return;
+        }
+
+        Integer claimId = parseInt(req.getParameter("claimId"));
+        String action = trim(req.getParameter("action"));
+
+        if (claimId == null || action == null) {
+            res.sendError(HttpServletResponse.SC_BAD_REQUEST, "Missing claim id or action.");
+            return;
+        }
+
+        try {
+            if ("approve".equals(action)) {
+                applyAction(userId, claimId, "APPROVED");
+                setFlash(session, "success", "Claim approved.");
+            } else if ("reject".equals(action)) {
+                applyAction(userId, claimId, "REJECTED");
+                setFlash(session, "success", "Claim rejected.");
+            } else {
+                res.sendError(HttpServletResponse.SC_BAD_REQUEST, "Unknown action.");
+                return;
+            }
+            res.sendRedirect(req.getContextPath() + "/admin/claims");
+        } catch (SQLException e) {
+            getServletContext().log("Admin claim action failed", e);
+            setFlash(session, "error", "Could not update claim.");
+            res.sendRedirect(req.getContextPath() + "/admin/claims");
+        }
+    }
+
+    static void applyAction(int adminUserId, int claimId, String newStatus) throws SQLException {
+        try (Connection conn = DBConnection.get()) {
+            conn.setAutoCommit(false);
+
+            try {
+                int listingId;
+                String currentStatus;
+
+                try (PreparedStatement ps = conn.prepareStatement(
+                        "SELECT listing_id, status FROM claims WHERE claim_id = ? FOR UPDATE")) {
+                    ps.setInt(1, claimId);
+
+                    try (ResultSet rs = ps.executeQuery()) {
+                        if (!rs.next()) {
+                            conn.rollback();
+                            return;
+                        }
+                        listingId = rs.getInt("listing_id");
+                        currentStatus = rs.getString("status");
+                    }
+                }
+
+                // idempotent: only PENDING claims can transition
+                if (!"PENDING".equals(currentStatus)) {
+                    conn.rollback();
+                    return;
+                }
+
+                try (PreparedStatement ps = conn.prepareStatement(
+                        "UPDATE claims SET status = ? WHERE claim_id = ?")) {
+                    ps.setString(1, newStatus);
+                    ps.setInt(2, claimId);
+                    ps.executeUpdate();
+                }
+
+                // on approve, lock the listing so others can't claim it
+                if ("APPROVED".equals(newStatus)) {
+                    try (PreparedStatement ps = conn.prepareStatement(
+                            "UPDATE listings SET status = 'CLAIMED' WHERE listing_id = ?")) {
+                        ps.setInt(1, listingId);
+                        ps.executeUpdate();
+                    }
+                }
+
+                String auditAction = "APPROVED".equals(newStatus) ? "APPROVE_CLAIM" : "REJECT_CLAIM";
+                writeAuditLog(conn, adminUserId, auditAction, "CLAIM", claimId);
+
+                conn.commit();
+            } catch (SQLException e) {
+                conn.rollback();
+                throw e;
+            }
+        }
+    }
+
+    private static int nextId(Connection conn, String table, String idColumn) throws SQLException {
+        String sql = "SELECT COALESCE(MAX(" + idColumn + "), 0) + 1 FROM " + table;
+        try (PreparedStatement ps = conn.prepareStatement(sql);
+             ResultSet rs = ps.executeQuery()) {
+            rs.next();
+            return rs.getInt(1);
+        }
+    }
+
+    private static void writeAuditLog(Connection conn, int userId, String actionType,
+                                      String entityType, int entityId) throws SQLException {
+        int logId = nextId(conn, "auditlogs", "log_id");
+
+        try (PreparedStatement ps = conn.prepareStatement(
+                "INSERT INTO auditlogs (log_id, user_id, action_type, entity_type, entity_id, action_time) "
+              + "VALUES (?, ?, ?, ?, ?, ?)")) {
+            ps.setInt(1, logId);
+            ps.setInt(2, userId);
+            ps.setString(3, actionType);
+            ps.setString(4, entityType);
+            ps.setInt(5, entityId);
+            ps.setTimestamp(6, Timestamp.valueOf(LocalDateTime.now()));
+            ps.executeUpdate();
+        }
+    }
+
+    private static void setFlash(HttpSession session, String type, String message) {
+        if (session == null) return;
+        session.setAttribute("flashType", type);
+        session.setAttribute("flashMessage", message);
+    }
+
+    private static String getSessionRole(HttpSession session) {
+        if (session == null) return null;
+        Object value = session.getAttribute("role");
+        return (value instanceof String) ? (String) value : null;
+    }
+
+    private static Integer getSessionUserId(HttpSession session) {
+        if (session == null) return null;
+        Object value = session.getAttribute("userId");
+        return (value instanceof Integer) ? (Integer) value : null;
+    }
+
+    private static Integer parseInt(String s) {
+        try {
+            return (s == null || s.trim().isEmpty()) ? null : Integer.valueOf(s.trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private static String trim(String s) {
+        return s == null ? null : s.trim();
+    }
+}

--- a/flowchain/src/main/java/com/flowchain/servlet/AdminClaimsServlet.java
+++ b/flowchain/src/main/java/com/flowchain/servlet/AdminClaimsServlet.java
@@ -1,6 +1,7 @@
 package com.flowchain.servlet;
 
 import com.flowchain.db.DBConnection;
+import com.flowchain.util.CsrfUtil;
 
 import java.io.IOException;
 import java.sql.*;
@@ -49,6 +50,8 @@ public class AdminClaimsServlet extends HttpServlet {
 
         try {
 
+            req.setAttribute("csrfToken", CsrfUtil.getOrCreate(req));
+            moveFlashToRequest(req);
             req.setAttribute("claims", loadClaims());
 
             req.getRequestDispatcher("/WEB-INF/views/admin-claims.jsp")
@@ -96,5 +99,20 @@ public class AdminClaimsServlet extends HttpServlet {
         }
 
         return rows;
+    }
+
+    private static void moveFlashToRequest(HttpServletRequest req) {
+        HttpSession session = req.getSession(false);
+        if (session == null) return;
+
+        Object type = session.getAttribute("flashType");
+        Object message = session.getAttribute("flashMessage");
+
+        if (type != null && message != null) {
+            req.setAttribute(String.valueOf(type), message);
+        }
+
+        session.removeAttribute("flashType");
+        session.removeAttribute("flashMessage");
     }
 }

--- a/flowchain/src/main/webapp/WEB-INF/views/admin-claims.jsp
+++ b/flowchain/src/main/webapp/WEB-INF/views/admin-claims.jsp
@@ -16,6 +16,18 @@
       View and manage all recipient claims.
     </p>
 
+    <c:if test="${not empty success}">
+      <div class="dashboard-placeholder">
+        <p><strong><c:out value="${success}" /></strong></p>
+      </div>
+    </c:if>
+
+    <c:if test="${not empty error}">
+      <div class="dashboard-placeholder">
+        <p><strong><c:out value="${error}" /></strong></p>
+      </div>
+    </c:if>
+
     <div class="listings-grid">
 
       <c:forEach var="claim" items="${claims}">
@@ -54,16 +66,16 @@
             <c:out value="${claim.claimId}" />
           </p>
 
-          <c:if test="${claim.status == 'REQUESTED'}">
+          <c:if test="${claim.status == 'PENDING'}">
 
             <div class="filter-actions">
 
               <form method="post"
-                    action="${pageContext.request.contextPath}/donor/claim-action">
+                    action="${pageContext.request.contextPath}/admin/claim/action">
 
                 <input type="hidden"
                        name="csrfToken"
-                       value="<c:out value='${sessionScope.csrfToken}' />">
+                       value="<c:out value='${csrfToken}' />">
 
                 <input type="hidden"
                        name="claimId"
@@ -83,11 +95,11 @@
               </form>
 
               <form method="post"
-                    action="${pageContext.request.contextPath}/donor/claim-action">
+                    action="${pageContext.request.contextPath}/admin/claim/action">
 
                 <input type="hidden"
                        name="csrfToken"
-                       value="<c:out value='${sessionScope.csrfToken}' />">
+                       value="<c:out value='${csrfToken}' />">
 
                 <input type="hidden"
                        name="claimId"


### PR DESCRIPTION
## Summary
  
  - Wires up admin approve/reject for recipient claims. The admin-claims.jsp page had Approve / Reject buttons, but they posted to /donor/claim-action — a URL with no servlet behind it. Clicking either button hit a 404, so admins had no way to act on pending claims.
  - Adds a new AdminClaimActionServlet at /admin/claim/action (POST-only) that performs the status transition transactionally. The new path lives under /admin/*, which AuthFilter already restricts to the ADMIN role.
  - Fixes the broken button visibility guard. The JSP only rendered the buttons when claim.status == 'REQUESTED', but claims are inserted with status PENDING (see ClaimListingServlet). The guard is now == 'PENDING', so the buttons actually appear on pending claims.

## Behavior
  - Approve → claims.status: PENDING → APPROVED and listings.status → CLAIMED (mirrors the existing donor-side approve flow in UpdateClaimStatusServlet).
  - Reject → claims.status: PENDING → REJECTED. The listing stays OPEN so other recipients can still claim it (matches the cancel-claim behavior in CancelClaimServlet).
  - Idempotent. If the claim is missing or already in a terminal state, the servlet silently no-ops — no double-transitions, no audit-log noise.
  - Audited. Each successful action writes an auditlogs row (APPROVE_CLAIM / REJECT_CLAIM, entity_type CLAIM) under the admin's userId.
  - CSRF + role checked. POSTs without a valid session CSRF token return 403; the servlet also re-checks session.role == "ADMIN" defense-in-depth on top of AuthFilter.
  - Flash messages. Success / error feedback is set on the session and surfaced on the next /admin/claims render.
